### PR TITLE
feat(Prophet-coeffs): DS-2469 store prophet coeffs

### DIFF
--- a/R/R/inputs.R
+++ b/R/R/inputs.R
@@ -678,6 +678,56 @@ build_prophet_coefficients_df <- function(regressor_names, coefs) {
     stringsAsFactors = FALSE
   )
 
+  message("Prophet coefficients DF built (without reference levels)")
+
+  return(prophet_coefficients)
+}
+
+####################################################################
+#' Add omitted reference levels to prophet regressor coefficients.
+#'
+#' When \code{ohse(redundant = FALSE)} is used, one level per factor is dropped.
+#' This function identifies those omitted levels from \code{factor_data} and
+#' appends them to \code{prophet_coefficients} with coefficient 0.
+#'
+#' @param prophet_coefficients Data frame with columns \code{regressor} and \code{coefficient}.
+#' @param factor_vars Character vector of factor variable names.
+#' @param factor_data Data frame containing the factor columns before one-hot encoding.
+#' @return The \code{prophet_coefficients} data frame with reference-level rows added (coef 0), sorted by \code{regressor}.
+add_reference_levels_to_prophet_coefficients <- function(prophet_coefficients,
+                                                          factor_vars,
+                                                          factor_data) {
+  # Regressors estimated by Prophet
+  present_regressors <- prophet_coefficients$regressor
+  # To store reference levels that Prophet omitted
+  omitted_regressors <- character(0L)
+
+  for (factor_var in factor_vars) {
+    if (!factor_var %in% names(factor_data)) next
+    
+    # Get all levels of the raw factor column
+    factor_col_raw <- factor_data[[factor_var]]
+    levels <- if (is.factor(factor_col_raw)) levels(factor_col_raw) else as.character(unique(factor_col_raw))
+    levels <- levels[!is.na(levels)]
+
+    if (length(levels) == 0L) next
+
+    ohe_cols_full <- paste0(factor_var, "_", levels)
+
+    # Get the names of the reference levels that Prophet omitted
+    omitted_regressors <- c(omitted_regressors, setdiff(ohe_cols_full, present_regressors))
+  }
+
+  # Add the reference levels to the prophet_coefficients DF with coefficient 0
+  if (length(omitted_regressors) > 0L) {
+    reference_levels_df <- data.frame(regressor = omitted_regressors, coefficient = 0, stringsAsFactors = FALSE)
+    prophet_coefficients <- rbind(prophet_coefficients, reference_levels_df)
+    prophet_coefficients <- prophet_coefficients[order(prophet_coefficients$regressor), , drop = FALSE]
+    row.names(prophet_coefficients) <- NULL
+
+    message("Reference levels of factor variables added to Prophet coefficients DF")
+  }
+
   return(prophet_coefficients)
 }
 
@@ -686,12 +736,23 @@ build_prophet_coefficients_df <- function(regressor_names, coefs) {
 #' from the prophet model.
 #'
 #' @param prophet_model Prophet model object.
+#' @param factor_vars Character vector of factor variable names.
+#' @param factor_data Data frame containing the factor columns
+#'   \emph{before} one-hot encoding (e.g. \code{dt_regressors}). Must contain
+#'   \code{factor_vars} columns. Used to derive all OHE level names so the
+#'   omitted reference level can be added with coefficient 0 when
+#'   \code{ohse(redundant = FALSE)} was used.
 #' @return A DataFrame containing the prophet regressor coefficients
+#'         (including baseline level with coefficient 0 when requested),
 #'         or NULL if coefficients/regressors can't be extracted.
-extract_prophet_regressor_coefs <- function(prophet_model) {
+extract_prophet_regressor_coefs <- function(prophet_model,
+                                            factor_vars,
+                                            factor_data) {
+  if (is.null(factor_vars) && length(factor_vars) > 0L) return (NULL)
   if (is.null(prophet_model)) return(NULL)
   if (is.null(prophet_model$params) || is.null(prophet_model$params$beta)) return(NULL)
   if (is.null(prophet_model$extra_regressors)) return(NULL)
+  if (is.null(factor_data) && !is.data.frame(factor_data)) return (NULL)
 
   regressor_names <- names(prophet_model$extra_regressors)
   if (length(regressor_names) == 0) return(NULL)
@@ -699,7 +760,7 @@ extract_prophet_regressor_coefs <- function(prophet_model) {
   beta_matrix <- prophet_model$params$beta
   if (is.null(dim(beta_matrix)) || ncol(beta_matrix) == 0) return(NULL)
 
-  # regressors are the last K columns 
+  # regressors are the last K columns
   k <- length(regressor_names)
   if (ncol(beta_matrix) < k) return(NULL)
 
@@ -708,8 +769,19 @@ extract_prophet_regressor_coefs <- function(prophet_model) {
   regressor_cols <- start_idx:ncol(beta_matrix)
 
   coefs <- colMeans(beta_matrix[, regressor_cols, drop = FALSE])
+
+  # Build the prophet_coefficients DF
   prophet_coefficients <- build_prophet_coefficients_df(regressor_names, coefs)
-  
+
+  # Get the omitted reference levels and add them to the prophet_coefficients DF with coefficient 0
+  prophet_coefficients <- add_reference_levels_to_prophet_coefficients(
+    prophet_coefficients,
+    factor_vars,
+    factor_data
+  )
+
+  message("Prophet coefficients DF built (with reference levels)")
+
   return(prophet_coefficients)
 }
 #! EA END
@@ -828,8 +900,13 @@ prophet_decomp <- function(dt_transform, dt_holidays,
   # return (dt_transform)
 
   #! EA START
-  prophet_coefficients <- extract_prophet_regressor_coefs(prophet_model)
-  
+  # Get the prophet regressor coefficients for factor variables
+  prophet_coefficients <- extract_prophet_regressor_coefs(
+    prophet_model,
+    factor_vars,
+    dt_regressors
+  )
+
   #! SH START
   # Needed to return multiple objects
   prophet_custom_output <- list(prophet_model = prophet_model,

--- a/R/R/inputs.R
+++ b/R/R/inputs.R
@@ -661,6 +661,58 @@ robyn_engineering <- function(x, quiet = FALSE, ...) {
   return(InputCollect)
 }
 
+#! EA START
+
+####################################################################
+#' Helper function to build the output DataFrame for prophet 
+#' regressor coefficients..
+#'
+#' @param regressor_names Character vector of regressor names.
+#' @param coefs Numeric vector of coefficients.
+#' @return A DataFrame containing the prophet regressor coefficients
+#'         or NULL if coefficients/regressors can't be extracted.
+build_prophet_coefficients_df <- function(regressor_names, coefs) {
+  prophet_coefficients <- data.frame(
+    regressor = regressor_names,
+    coefficient = as.numeric(coefs),
+    stringsAsFactors = FALSE
+  )
+
+  return(prophet_coefficients)
+}
+
+####################################################################
+#' This function extracts the prophet regressor coefficients 
+#' from the prophet model.
+#'
+#' @param prophet_model Prophet model object.
+#' @return A DataFrame containing the prophet regressor coefficients
+#'         or NULL if coefficients/regressors can't be extracted.
+extract_prophet_regressor_coefs <- function(prophet_model) {
+  if (is.null(prophet_model)) return(NULL)
+  if (is.null(prophet_model$params) || is.null(prophet_model$params$beta)) return(NULL)
+  if (is.null(prophet_model$extra_regressors)) return(NULL)
+
+  regressor_names <- names(prophet_model$extra_regressors)
+  if (length(regressor_names) == 0) return(NULL)
+
+  beta_matrix <- prophet_model$params$beta
+  if (is.null(dim(beta_matrix)) || ncol(beta_matrix) == 0) return(NULL)
+
+  # regressors are the last K columns 
+  k <- length(regressor_names)
+  if (ncol(beta_matrix) < k) return(NULL)
+
+  # In most Prophet implementations, extra regressors live in the last K beta columns.
+  start_idx <- ncol(beta_matrix) - k + 1
+  regressor_cols <- start_idx:ncol(beta_matrix)
+
+  coefs <- colMeans(beta_matrix[, regressor_cols, drop = FALSE])
+  prophet_coefficients <- build_prophet_coefficients_df(regressor_names, coefs)
+  
+  return(prophet_coefficients)
+}
+#! EA END
 
 ####################################################################
 #' Conduct prophet decomposition
@@ -776,50 +828,7 @@ prophet_decomp <- function(dt_transform, dt_holidays,
   # return (dt_transform)
 
   #! EA START
-  # Extract prophet regressor coefficients
-  prophet_coefficients <- NULL
-  if (!is.null(prophet_model) && !is.null(prophet_model$params) && !is.null(prophet_model$params$beta)) {
-    # Get regressor names from extra_regressors
-    regressor_names <- names(prophet_model$extra_regressors)
-    
-    if (length(regressor_names) > 0 && ncol(prophet_model$params$beta) > 0) {
-      # Extract beta coefficients (mean across samples)
-      # beta is a matrix: rows are samples, columns are regressors
-      beta_matrix <- prophet_model$params$beta
-      
-      # Get the column indices for regressors (skip trend, seasonality components)
-      # Regressors start after the base components
-      n_base_components <- ncol(beta_matrix) - length(regressor_names)
-      regressor_indices <- (n_base_components + 1):ncol(beta_matrix)
-      
-      if (length(regressor_indices) == length(regressor_names)) {
-        # Calculate mean coefficient for each regressor across samples
-        regressor_coefs <- colMeans(beta_matrix[, regressor_indices, drop = FALSE])
-        
-        # Create data frame with regressor names and coefficients
-        prophet_coefficients <- data.frame(
-          regressor = regressor_names,
-          coefficient = as.numeric(regressor_coefs),
-          stringsAsFactors = FALSE
-        )
-      } else {
-        # Fallback: try to match by position or extract all extra regressor columns
-        # Prophet stores regressors in extra_regressors, and their coefficients in beta
-        # The order should match
-        if (ncol(beta_matrix) >= length(regressor_names)) {
-          # Take the last columns matching the number of regressors
-          start_idx <- ncol(beta_matrix) - length(regressor_names) + 1
-          regressor_coefs <- colMeans(beta_matrix[, start_idx:ncol(beta_matrix), drop = FALSE])
-          
-          prophet_coefficients <- data.frame(
-            regressor = regressor_names,
-            coefficient = as.numeric(regressor_coefs),
-            stringsAsFactors = FALSE
-          )
-        }
-      }
-    }
-  }
+  prophet_coefficients <- extract_prophet_regressor_coefs(prophet_model)
   
   #! SH START
   # Needed to return multiple objects

--- a/R/R/inputs.R
+++ b/R/R/inputs.R
@@ -707,15 +707,38 @@ add_reference_levels_to_prophet_coefficients <- function(prophet_coefficients,
     
     # Get all levels of the raw factor column
     factor_col_raw <- factor_data[[factor_var]]
-    levels <- if (is.factor(factor_col_raw)) levels(factor_col_raw) else as.character(unique(factor_col_raw))
-    levels <- levels[!is.na(levels)]
+    levels_for_factor <- if (is.factor(factor_col_raw)) levels(factor_col_raw) else as.character(unique(factor_col_raw))
+    levels_for_factor <- levels_for_factor[!is.na(levels_for_factor)]
+    n_levels_for_factor <- length(levels_for_factor)
 
-    if (length(levels) == 0L) next
+    if (n_levels_for_factor == 0L) next
+    
+    # Get all OHE columns for the factor
+    ohe_cols_full_for_factor <- paste0(factor_var, "_", levels_for_factor)
+    
+    # Get present regressors names and amount for the factor
+    present_regressors_for_factor <- present_regressors[grepl(paste0("^", factor_var, "_"), present_regressors)]
+    n_present_regressors_for_factor <- length(present_regressors_for_factor)
 
-    ohe_cols_full <- paste0(factor_var, "_", levels)
+    # Get omitted regressors names and amount for the factor
+    omitted_regressors_for_factor <- setdiff(ohe_cols_full_for_factor, present_regressors_for_factor)
+    n_omitted_regressors_for_factor <- length(omitted_regressors_for_factor)
 
-    # Get the names of the reference levels that Prophet omitted
-    omitted_regressors <- c(omitted_regressors, setdiff(ohe_cols_full, present_regressors))
+    # Add omitted regressors for factor names to the general omitted regressors list
+    omitted_regressors <- c(omitted_regressors, omitted_regressors_for_factor)
+
+    # Regressors names and amount the factor should have (omitted will be added later out of this loop)
+    all_regressors_for_factor <- c(present_regressors_for_factor, omitted_regressors_for_factor)
+    n_all_regressors_for_factor <- length(all_regressors_for_factor)
+
+    # Check if the total amount of regressors is equal to the number of unique values for the factor
+    if (n_all_regressors_for_factor != n_levels_for_factor) {
+      stop(
+        "Factor '", factor_var, "': number of regressors (", n_all_regressors_for_factor,
+        ") != number of unique values (", n_levels_for_factor, "). ",
+        "Regressors: ", paste(all_regressors_for_factor, collapse = ", ")
+      )
+    }
   }
 
   # Add the reference levels to the prophet_coefficients DF with coefficient 0

--- a/R/R/inputs.R
+++ b/R/R/inputs.R
@@ -775,13 +775,61 @@ prophet_decomp <- function(dt_transform, dt_holidays,
 
   # return (dt_transform)
 
+  #! EA START
+  # Extract prophet regressor coefficients
+  prophet_coefficients <- NULL
+  if (!is.null(prophet_model) && !is.null(prophet_model$params) && !is.null(prophet_model$params$beta)) {
+    # Get regressor names from extra_regressors
+    regressor_names <- names(prophet_model$extra_regressors)
+    
+    if (length(regressor_names) > 0 && ncol(prophet_model$params$beta) > 0) {
+      # Extract beta coefficients (mean across samples)
+      # beta is a matrix: rows are samples, columns are regressors
+      beta_matrix <- prophet_model$params$beta
+      
+      # Get the column indices for regressors (skip trend, seasonality components)
+      # Regressors start after the base components
+      n_base_components <- ncol(beta_matrix) - length(regressor_names)
+      regressor_indices <- (n_base_components + 1):ncol(beta_matrix)
+      
+      if (length(regressor_indices) == length(regressor_names)) {
+        # Calculate mean coefficient for each regressor across samples
+        regressor_coefs <- colMeans(beta_matrix[, regressor_indices, drop = FALSE])
+        
+        # Create data frame with regressor names and coefficients
+        prophet_coefficients <- data.frame(
+          regressor = regressor_names,
+          coefficient = as.numeric(regressor_coefs),
+          stringsAsFactors = FALSE
+        )
+      } else {
+        # Fallback: try to match by position or extract all extra regressor columns
+        # Prophet stores regressors in extra_regressors, and their coefficients in beta
+        # The order should match
+        if (ncol(beta_matrix) >= length(regressor_names)) {
+          # Take the last columns matching the number of regressors
+          start_idx <- ncol(beta_matrix) - length(regressor_names) + 1
+          regressor_coefs <- colMeans(beta_matrix[, start_idx:ncol(beta_matrix), drop = FALSE])
+          
+          prophet_coefficients <- data.frame(
+            regressor = regressor_names,
+            coefficient = as.numeric(regressor_coefs),
+            stringsAsFactors = FALSE
+          )
+        }
+      }
+    }
+  }
+  
   #! SH START
   # Needed to return multiple objects
   prophet_custom_output <- list(prophet_model = prophet_model,
-              prophet_input = prophet_input)
+              prophet_input = prophet_input,
+              prophet_coefficients = prophet_coefficients)
   return(list(dt_transform = dt_transform,
               prophet_custom_output = prophet_custom_output))
   #! SH END
+  #! EA END
 }
 
 exposure_handling <- function(dt_transform,

--- a/R/R/outputs.R
+++ b/R/R/outputs.R
@@ -333,7 +333,7 @@ robyn_csv <- function(InputCollect, OutputCollect, csv_out = NULL, export = TRUE
         !is.null(InputCollect$prophet_custom_output$prophet_coefficients)) {
       prophet_coefs <- InputCollect$prophet_custom_output$prophet_coefficients
       if (!is.null(prophet_coefs) && nrow(prophet_coefs) > 0) {
-        write.csv(prophet_coefs, paste0(plot_folder, "prophet_regressor_coefficients.csv"), row.names = FALSE)
+        write.csv(prophet_coefs, paste0(plot_folder, "prophet_regressor_coefficients.csv"), row.names = TRUE)
       }
     }
     #! EA END

--- a/R/R/outputs.R
+++ b/R/R/outputs.R
@@ -329,12 +329,14 @@ robyn_csv <- function(InputCollect, OutputCollect, csv_out = NULL, export = TRUE
     
     #! EA START
     # Save prophet regressor coefficients if available
-    if (!is.null(InputCollect$prophet_custom_output) && 
-        !is.null(InputCollect$prophet_custom_output$prophet_coefficients)) {
-      prophet_coefs <- InputCollect$prophet_custom_output$prophet_coefficients
-      if (!is.null(prophet_coefs) && nrow(prophet_coefs) > 0) {
-        write.csv(prophet_coefs, paste0(plot_folder, "prophet_regressor_coefficients.csv"), row.names = TRUE)
-      }
+    prophet_coefs <- InputCollect$prophet_custom_output$prophet_coefficients
+
+    if (!is.null(prophet_coefs) && nrow(prophet_coefs) > 0) {
+      write.csv(
+        prophet_coefs,
+        file = paste0(plot_folder, "prophet_regressor_coefficients.csv"),
+        row.names = TRUE
+      )
     }
     #! EA END
   }

--- a/R/R/outputs.R
+++ b/R/R/outputs.R
@@ -326,5 +326,16 @@ robyn_csv <- function(InputCollect, OutputCollect, csv_out = NULL, export = TRUE
       write.csv(OutputCollect$mediaVecCollect, paste0(plot_folder, "pareto_media_transform_matrix.csv"))
       write.csv(OutputCollect$xDecompVecCollect, paste0(plot_folder, "pareto_alldecomp_matrix.csv"))
     }
+    
+    #! EA START
+    # Save prophet regressor coefficients if available
+    if (!is.null(InputCollect$prophet_custom_output) && 
+        !is.null(InputCollect$prophet_custom_output$prophet_coefficients)) {
+      prophet_coefs <- InputCollect$prophet_custom_output$prophet_coefficients
+      if (!is.null(prophet_coefs) && nrow(prophet_coefs) > 0) {
+        write.csv(prophet_coefs, paste0(plot_folder, "prophet_regressor_coefficients.csv"), row.names = FALSE)
+      }
+    }
+    #! EA END
   }
 }


### PR DESCRIPTION
## SUMMARY

When a Robyn run is executed, and `factor_vars` are specified, a new CSV file (`prophet_regressor_coefficients.csv`) will be created within the Robyn init folder. The motivation for saving the prophet regressors, comes with the need of handling categorical variables within Scenario Modeling predict flow, for which prophet regressors of categorical variables are needed to transform the values. 
The regressors will be named as `<variable>_<value>`, where `<value>` is each value of the categorical variable present in the dataset.

Example of `prophet_regressor_coefficients.csv` with `factor_vars = c('Marathons', 'RandomVariable')`:
|  | regressor | coefficient |
| :--- | :--- | :--- |
| 1 | Marathons_0 | -0.014 |
| 2 | Marathons_1 | 0.006 |
| 1 | RandomVariable_X | -0.003 |
| 2 | RandomVariable_Y | 0.006 |


It's worth noting, that in the original dataset that generated the above example, we have the values `0`, `1`, and `2` for the variable `Marathons`, and values `X`, `Y`, and `Z` for the variable `RandomVariable`. Prophet takes one of the values as reference and omits it at the moment of the coefficient generation.

1. Added code to extract the Prophet's coefficients on `R/R/inputs.R` (outlined by comments: #! EA START, !# EA END).
2. Save Prophet's coefficients on a new CSV on `R/R/outputs.R`.


**NOTE:** This changes' output were envisioned for the changes mentioned on this other [PR](https://github.com/GoodwayGroup/ds-scenario-modeling/pull/318)

## STORY NUMBER and LINK
[DS-2469](https://goodwaygroup.atlassian.net/browse/DS-2469)


[DS-2469]: https://goodwaygroup.atlassian.net/browse/DS-2469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ